### PR TITLE
Adding south_field_triple method to CompositionField to fix south compatibility problem.

### DIFF
--- a/composition/base.py
+++ b/composition/base.py
@@ -81,3 +81,14 @@ class CompositionField(object):
 
     def introspect_class(self, cls):
         pass
+
+    def south_field_triple(self):
+        """
+        Returns a suitable description of this field for South.
+        """
+        # We'll just introspect the _actual_ field.
+        from south.modelsinspector import introspector
+        field_class = self._c_native.__class__.__module__ + "." + self._c_native.__class__.__name__
+        args, kwargs = introspector(self._c_native)
+        # That's our definition!
+        return (field_class, args, kwargs)


### PR DESCRIPTION
Adding a CompositionField to one of your models, and then trying to
migrate (using south) any other field would break since south doesn't
know how to serialize a CompositionField to add it in the frozen models.

Adding south_field_triple method to the CompositionField to return its
representation, solves this problem.
